### PR TITLE
Update VMWareTools.md (New-CIPolicy)

### DIFF
--- a/Policies/VMWareTools.md
+++ b/Policies/VMWareTools.md
@@ -32,7 +32,7 @@ $VMWareFilesUser2 = Get-SystemDriver -ScanPath "$Env:ProgramFiles\VMware\VMware 
 
 [Microsoft.SecureBoot.UserConfig.DriverFile[]] $AllVMWareFiles = $VMWareInstallerDiscDriverFiles + $VMWareInstallerDiscUserFiles + $VMWareFilesDrivers + $VMWareFilesUser1 + $VMWareFilesUser2
 
-New-CIPolicy -DriverFiles $AllVMWareFiles -FilePath 'VMWareTools.xml' -Level 'WHQLFilePublisher' -Fallback 'FilePublisher, Hash'
+New-CIPolicy -DriverFiles $AllVMWareFiles -FilePath 'VMWareTools.xml' -Level 'WHQLFilePublisher' -Fallback 'FilePublisher', 'Hash'
 ```
 
 # Software build hygeine observations


### PR DESCRIPTION
The command "New-CIPolicy -DriverFiles $AllVMWareFiles -FilePath 'VMWareTools.xml' -Level 'WHQLFilePublisher' -Fallback 'FilePublisher, Hash'" does not use multiple fallbacks if the syntax is not ('FilePublisher', 'Hash')